### PR TITLE
feature: implemented way to import from gist

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,9 @@ pub enum LostTheWay {
     /// Sync Error
     #[error("SyncError: {message:?}")]
     SyncError { message: String },
+    /// Error due to invalid Gist URL
+    #[error("GistUrlError: {message:?}")]
+    GistUrlError { message: String },
     /// Catch-all for stuff that should never happen
     #[error("OutOfCheeseError: {message:?}\nRedo from start.")]
     OutOfCheeseError { message: String },

--- a/src/the_way/cli.rs
+++ b/src/the_way/cli.rs
@@ -71,6 +71,17 @@ pub enum TheWayCLI {
         #[structopt(parse(from_os_str))]
         file: Option<PathBuf>,
     },
+    /// Imports code snippets from a Gist given the URL.
+    ///
+    /// Multiple files will be converted to separate snippets.
+    /// Snippet description is created based on Gist description and file name with the format 
+    /// "<gist_description> - <file_name>".
+    /// Each snippet will be tagged with "gist" and its Gist ID.
+    /// Works for both secret and public gists.
+    ImportGist {
+        /// Gist URL
+        gist_url: String,
+    },
     /// Saves (optionally filtered) snippets to JSON.
     Export {
         /// filename, writes to stdout if not given

--- a/src/the_way/cli.rs
+++ b/src/the_way/cli.rs
@@ -65,22 +65,22 @@ pub enum TheWayCLI {
     },
     /// Imports code snippets from JSON.
     ///
-    /// Looks for description, language, and code fields
+    /// Looks for description, language, and code fields.
     Import {
         /// filename, reads from stdin if not given
         #[structopt(parse(from_os_str))]
         file: Option<PathBuf>,
-    },
-    /// Imports code snippets from a Gist given the URL.
-    ///
-    /// Multiple files will be converted to separate snippets.
-    /// Snippet description is created based on Gist description and file name with the format 
-    /// "<gist_description> - <file_name>".
-    /// Each snippet will be tagged with "gist" and its Gist ID.
-    /// Works for both secret and public gists.
-    ImportGist {
-        /// Gist URL
-        gist_url: String,
+
+        #[structopt(long, short)]
+
+        /// URL to a Gist, if provided will import snippets from given Gist
+        ///
+        /// Multiple files will be converted to separate snippets.
+        /// Snippet description is created based on Gist description and file name with the format
+        /// "<gist_description> - <gist_id> - <file_name>".
+        /// Each snippet will be tagged with "gist" and its Gist ID.
+        /// Works for both secret and public gists.
+        gist_url: Option<String>,
     },
     /// Saves (optionally filtered) snippets to JSON.
     Export {

--- a/src/the_way/gist.rs
+++ b/src/the_way/gist.rs
@@ -1,25 +1,45 @@
-//! Code related to syncing snippets to Gist
+//! Code related to dealing with Gists
 use std::collections::HashMap;
 
 use color_eyre::Help;
 
 use crate::errors::LostTheWay;
 use crate::gist::{CreateGistPayload, GistClient, GistContent, UpdateGistPayload};
-use crate::the_way::TheWay;
+use crate::the_way::{snippet::Snippet, TheWay};
 use crate::utils;
 
 /// Gist description
 const DESCRIPTION: &str = "The Way Code Snippets";
 /// Heading for the index.md file
 const INDEX: &str = "# Is it not written...\n";
-const USER_AGENT: &str = "the-way";
 
 impl TheWay {
+    /// Import Snippets from a regular Gist
+    pub(crate) fn import_gist(&mut self, gist_url: &str) -> color_eyre::Result<Vec<Snippet>> {
+        // it's assumed that access token is not required when reading Gists
+        let client = GistClient::new(None)?;
+
+        let spinner = utils::get_spinner("Fetching gist...");
+        let gist = client.get_gist_by_url(gist_url);
+        if let Err(err) = gist {
+            spinner.finish_with_message("Error fetching gist.");
+            return Err(err);
+        }
+        let gist = gist.unwrap();
+        let start_index = self.get_current_snippet_index()?;
+        let snippets = Snippet::from_gist(start_index, &self.languages, &gist)?;
+        for snippet in &snippets {
+            self.add_snippet(&snippet)?;
+            self.increment_snippet_index()?;
+        }
+        Ok(snippets)
+    }
+
     /// Creates a Gist with each code snippet as a separate file (named snippet_<index>.<ext>)
     /// and an index file (index.md) listing each snippet's description
     pub(crate) fn make_gist(&self, access_token: &str) -> color_eyre::Result<String> {
         // Make client
-        let client = GistClient::new(access_token, USER_AGENT)?;
+        let client = GistClient::new(Some(access_token))?;
         // Start creating
         let spinner = utils::get_spinner("Creating Gist...");
 
@@ -79,10 +99,7 @@ impl TheWay {
     /// Syncs local and Gist snippets
     pub(crate) fn sync_gist(&mut self) -> color_eyre::Result<()> {
         // Make client
-        let client = GistClient::new(
-            self.config.github_access_token.as_ref().unwrap(),
-            USER_AGENT,
-        )?;
+        let client = GistClient::new(self.config.github_access_token.as_deref())?;
 
         // Start sync
         let spinner = utils::get_spinner("Syncing...");

--- a/src/the_way/gist.rs
+++ b/src/the_way/gist.rs
@@ -26,7 +26,7 @@ impl TheWay {
             return Err(err);
         }
         let gist = gist.unwrap();
-        let start_index = self.get_current_snippet_index()?;
+        let start_index = self.get_current_snippet_index()? + 1;
         let snippets = Snippet::from_gist(start_index, &self.languages, &gist)?;
         for snippet in &snippets {
             self.add_snippet(&snippet)?;

--- a/src/the_way/mod.rs
+++ b/src/the_way/mod.rs
@@ -86,6 +86,13 @@ impl TheWay {
             }
             TheWayCLI::View { index } => self.view(*index),
             TheWayCLI::List { filters } => self.list(filters),
+            TheWayCLI::ImportGist { gist_url } => {
+                let gist_url = gist_url.clone();
+                let snippets = self.import_gist(&gist_url)?;
+                println!("Imported {} snippets from {}", snippets.len(), gist_url);
+                self.show_snippets(&snippets)?;
+                Ok(())
+            }
             TheWayCLI::Import { file } => {
                 let mut num = 0;
                 for mut snippet in self.import(file.as_deref())? {
@@ -229,13 +236,11 @@ impl TheWay {
         Ok(())
     }
 
-    /// Lists snippets (optionally filtered)
-    fn list(&self, filters: &Filters) -> color_eyre::Result<()> {
-        let mut snippets = self.filter_snippets(filters)?;
-        snippets.sort_by(|a, b| a.index.cmp(&b.index));
+    /// Prints given snippets
+    fn show_snippets(&self, snippets: &Vec<Snippet>) -> color_eyre::Result<()> {
         let mut colorized = Vec::new();
         let default_language = Language::default();
-        for snippet in &snippets {
+        for snippet in snippets {
             colorized.extend_from_slice(
                 &snippet.pretty_print(
                     &self.highlighter,
@@ -248,6 +253,14 @@ impl TheWay {
         for line in colorized {
             print!("{}", line);
         }
+        Ok(())
+    }
+
+    /// Lists snippets (optionally filtered)
+    fn list(&self, filters: &Filters) -> color_eyre::Result<()> {
+        let mut snippets = self.filter_snippets(filters)?;
+        snippets.sort_by(|a, b| a.index.cmp(&b.index));
+        self.show_snippets(&snippets)?;
         Ok(())
     }
 

--- a/src/the_way/mod.rs
+++ b/src/the_way/mod.rs
@@ -86,20 +86,19 @@ impl TheWay {
             }
             TheWayCLI::View { index } => self.view(*index),
             TheWayCLI::List { filters } => self.list(filters),
-            TheWayCLI::ImportGist { gist_url } => {
-                let gist_url = gist_url.clone();
-                let snippets = self.import_gist(&gist_url)?;
-                println!("Imported {} snippets from {}", snippets.len(), gist_url);
-                self.show_snippets(&snippets)?;
-                Ok(())
-            }
-            TheWayCLI::Import { file } => {
+            TheWayCLI::Import { file, gist_url } => {
                 let mut num = 0;
-                for mut snippet in self.import(file.as_deref())? {
-                    snippet.index = self.get_current_snippet_index()? + 1;
-                    self.add_snippet(&snippet)?;
-                    self.increment_snippet_index()?;
-                    num += 1;
+                if let Some(gist_url) = gist_url {
+                    let gist_url = gist_url.clone();
+                    let snippets = self.import_gist(&gist_url)?;
+                    num = snippets.len();
+                } else {
+                    for mut snippet in self.import(file.as_deref())? {
+                        snippet.index = self.get_current_snippet_index()? + 1;
+                        self.add_snippet(&snippet)?;
+                        self.increment_snippet_index()?;
+                        num += 1;
+                    }
                 }
                 println!("Imported {} snippets", num);
                 Ok(())
@@ -236,8 +235,8 @@ impl TheWay {
         Ok(())
     }
 
-    /// Prints given snippets
-    fn show_snippets(&self, snippets: &Vec<Snippet>) -> color_eyre::Result<()> {
+    /// Prints given snippets in full
+    fn show_snippets(&self, snippets: &[Snippet]) -> color_eyre::Result<()> {
         let mut colorized = Vec::new();
         let default_language = Language::default();
         for snippet in snippets {

--- a/src/the_way/snippet.rs
+++ b/src/the_way/snippet.rs
@@ -177,7 +177,7 @@ impl Snippet {
             let code = &gist_file.content;
             let description = format!("{} - {} - {}", gist.description, gist.id, file_name);
             let language = &gist_file.language;
-            let tags = format!("gist {}", gist.id);
+            let tags = "gist";
             let extension = Language::get_extension(&language, languages);
             let snippet = Self::new(
                 index,

--- a/src/the_way/snippet.rs
+++ b/src/the_way/snippet.rs
@@ -175,7 +175,7 @@ impl Snippet {
         let mut snippets = Vec::new();
         for (file_name, gist_file) in &gist.files {
             let code = &gist_file.content;
-            let description = format!("{} - {}", gist.description, file_name);
+            let description = format!("{} - {} - {}", gist.description, gist.id, file_name);
             let language = &gist_file.language;
             let tags = format!("gist {}", gist.id);
             let extension = Language::get_extension(&language, languages);

--- a/src/the_way/snippet.rs
+++ b/src/the_way/snippet.rs
@@ -6,6 +6,7 @@ use std::io;
 use chrono::{DateTime, Utc};
 use regex::Regex;
 
+use crate::gist::Gist;
 use crate::language::{CodeHighlight, Language};
 use crate::utils;
 
@@ -162,6 +163,36 @@ impl Snippet {
     pub(crate) fn to_json(&self, json_writer: &mut dyn io::Write) -> color_eyre::Result<()> {
         serde_json::to_writer(json_writer, self)?;
         Ok(())
+    }
+
+    /// Read potentially multiple snippets from a regular Gist (not a sync/backup Gist)
+    pub(crate) fn from_gist(
+        start_index: usize,
+        languages: &HashMap<String, Language>,
+        gist: &Gist,
+    ) -> color_eyre::Result<Vec<Self>> {
+        let mut index = start_index;
+        let mut snippets = Vec::new();
+        for (file_name, gist_file) in &gist.files {
+            let code = &gist_file.content;
+            let description = format!("{} - {}", gist.description, file_name);
+            let language = &gist_file.language;
+            let tags = format!("gist {}", gist.id);
+            let extension = Language::get_extension(&language, languages);
+            let snippet = Self::new(
+                index,
+                description,
+                language.to_string(),
+                extension.to_string(),
+                &tags,
+                Utc::now(),
+                Utc::now(),
+                code.to_string(),
+            );
+            snippets.push(snippet);
+            index += 1;
+        }
+        Ok(snippets)
     }
 
     /// Filters snippets in date range

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -527,7 +527,8 @@ fn gist() -> color_eyre::Result<()> {
     assert!(config.gist_id.is_some());
 
     // get Gist
-    let client = GistClient::new(&std::env::var("THE_WAY_GITHUB_TOKEN")?, "the-way")?;
+    let token = &std::env::var("THE_WAY_GITHUB_TOKEN")?;
+    let client = GistClient::new(Some(token))?;
     let gist = client.get_gist(&config.gist_id.unwrap());
     assert!(gist.is_ok());
     let gist = gist?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -289,6 +289,9 @@ fn import_multiple_no_tags() -> color_eyre::Result<()> {
     Ok(())
 }
 
+// This test triggers Github rate limit when ran by CI.
+// Making it target a single platform as a hacky workaround.
+#[cfg(target_os = "macos")]
 #[test]
 fn import_gist() -> color_eyre::Result<()> {
     let temp_dir = tempdir()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -289,6 +289,9 @@ fn import_multiple_no_tags() -> color_eyre::Result<()> {
     Ok(())
 }
 
+// This test is ignored because it tries to fetch a real Gist and runs into
+// Github rate limits when ran by CI (not sure why this happens though).
+#[ignore]
 #[test]
 fn import_gist() -> color_eyre::Result<()> {
     let temp_dir = tempdir()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -289,9 +289,6 @@ fn import_multiple_no_tags() -> color_eyre::Result<()> {
     Ok(())
 }
 
-// This test triggers Github rate limit when ran by CI.
-// Making it target a single platform as a hacky workaround.
-#[cfg(target_os = "macos")]
 #[test]
 fn import_gist() -> color_eyre::Result<()> {
     let temp_dir = tempdir()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -290,6 +290,28 @@ fn import_multiple_no_tags() -> color_eyre::Result<()> {
 }
 
 #[test]
+fn import_gist() -> color_eyre::Result<()> {
+    let temp_dir = tempdir()?;
+    let config_file = make_config_file(&temp_dir)?;
+    let mut cmd = Command::cargo_bin("the-way")?;
+    cmd.env("THE_WAY_CONFIG", &config_file)
+        .arg("import")
+        .arg("-g https://gist.github.com/xiaochuanyu/e5deab8d78ce838f22f160c9b14daf17")
+        .assert()
+        .success();
+    let mut cmd = Command::cargo_bin("the-way")?;
+    cmd.env("THE_WAY_CONFIG", &config_file)
+        .arg("view")
+        .arg("1")
+        .assert()
+        .stdout(predicate::str::contains(
+            "the-way Test - e5deab8d78ce838f22f160c9b14daf17 - TestTheWay.java",
+        ));
+    temp_dir.close()?;
+    Ok(())
+}
+
+#[test]
 fn export() -> color_eyre::Result<()> {
     use the_way::the_way::snippet::Snippet;
 
@@ -492,7 +514,7 @@ fn copy_shell_script_rexpect(config_file: PathBuf) -> rexpect::errors::Result<()
 #[test]
 /// Tests Gist sync functionality. Needs to have the environment variable $THE_WAY_GITHUB_TOKEN set!
 /// Ignored by default since Travis doesn't allow secret/encrypted environment variables in PRs
-fn gist() -> color_eyre::Result<()> {
+fn gist_sync() -> color_eyre::Result<()> {
     use the_way::configuration::TheWayConfig;
     use the_way::gist::{GistClient, GistContent, UpdateGistPayload};
 


### PR DESCRIPTION
This PR tries to address #77.

One thing I wasn't sure how to do was extending `import` in backward compatible way so I added `import-gist` for now.
I assume we want something like the following instead:
```
the-way import https://gist.github.com/xiaochuanyu/66fd3b1a529ed01794cff091e08898ab
```
We can maybe try to accept a `String` and manually parse it? Let me know if you have any ideas.

I'm still kinda new to Rust so I would appreciate any feedback and would be happy to make any changes.

Quick demo of the work so far:
![the_way_gist](https://user-images.githubusercontent.com/1718745/95778579-6ee41080-0c96-11eb-86b2-ae2a7f9653c0.gif)

EDIT: this was implemented as `the-way import -g https://gist.github.com/xiaochuanyu/66fd3b1a529ed01794cff091e08898ab` instead.