### PR TITLE
Publish to the Arch User Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Table of Contents
   * [Binaries](#binaries)
   * [With brew](#with-brew)
   * [With cargo](#with-cargo)
+  * [With yay](#with-yay)
 * [Usage](#usage)
 * [Features](#features)
   * [Main features](#main-features)
@@ -54,6 +55,11 @@ brew tap out-of-cheese-error/the-way && brew install the-way
 ## With cargo
 ```bash
 cargo install the-way
+```
+
+## With yay
+```bash
+yay -S the-way
 ```
 
 **!!!NOTE: upgrading from <v0.5 needs a database migration, instructions below:**


### PR DESCRIPTION
Thanks for building this sick tool! I found this when looking for rust command line tools and am now going to use it as my code snipped manager. I want to help in distributing `the-way` to more users so I've published it to the Arch User Repository (AUR) [here](https://aur.archlinux.org/packages/the-way), which is a package repository for Arch Linux.

In this pull request, I just added `yay` (package manager for the AUR) as an installation method, let me know if I should change anything. Also, if you have an AUR account, I'd be happy to transfer ownership.