### PR TITLE
Update AUR Package Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cargo install the-way
 
 ## With yay
 ```bash
-yay -S the-way
+yay -S the-way-git
 ```
 
 **!!!NOTE: upgrading from <v0.5 needs a database migration, instructions below:**


### PR DESCRIPTION
Hi, I've had to change the AUR package name from `the-way` to [`the-way-git`](https://aur.archlinux.org/packages/the-way-git) in order to meet Arch Linux's [VCS package guidelines](https://wiki.archlinux.org/index.php/VCS_package_guidelines). This pull request just updates the package name in the README so that users download the correct package (the old one will soon be unavailable).