### PR TITLE
Include more useful message when copy_to_clipboard fails

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,8 +28,8 @@ pub enum LostTheWay {
     /// Thrown when trying to load a syntax which hasn't been added / doesn't exist
     #[error("SyntaxError: {syntax:?}")]
     SyntaxError { syntax: String },
-    #[error("ClipboardError: Couldn't copy to clipboard")]
-    ClipboardError,
+    #[error("ClipboardError: Couldn't copy to clipboard - {message}")]
+    ClipboardError { message: String },
     #[error("SearchError: Search failed")]
     SearchError,
     /// Errors related to changing the configuration file

--- a/src/the_way/snippet.rs
+++ b/src/the_way/snippet.rs
@@ -256,7 +256,7 @@ impl Snippet {
 
     pub(crate) fn copy(&self) -> color_eyre::Result<usize> {
         let code = self.fill_snippet()?;
-        utils::copy_to_clipboard(&code).expect("Clipboard Error");
+        utils::copy_to_clipboard(&code)?;
         Ok(self.index)
     }
 


### PR DESCRIPTION
Potential fix for panic when xclip is not installed. I've not got access to macos so tested on linux only.