### PR TITLE
update dialoguer to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 chrono-english = "0.1.4"
 
 # Taking user input and showing progress
-dialoguer = "0.7.1"
+dialoguer = "0.8.0"
 indicatif = "0.15.0"
 
 # Fuzzy search


### PR DESCRIPTION
Hello, there's some issues in the dependencies :
```sh
>> cargo install the-way
    Updating crates.io index
  Installing the-way v0.13.0
error: failed to compile `the-way v0.13.0`, intermediate artifacts can be found at `/tmp/cargo-installZLa2XP`

Caused by:
  failed to select a version for the requirement `zeroize = "^0.9.3"`
  candidate versions found which didn't match: 1.3.0, 1.2.0, 1.1.1, ...
  location searched: crates.io index
  required by package `dialoguer v0.7.1`
      ... which is depended on by `the-way v0.13.0`
```

Versions of `Zeroize` below `1.0.0` have been yanked so you need to update your version of `dialoguer` to 0.8.0 (which use `zeroize:1.1.1`)

Tests results seems ok :
```sh
 cargo test -- --test-threads=1
warning: function is never used: `copy_shell_script_rexpect`
   --> tests/cli.rs:479:4
    |
479 | fn copy_shell_script_rexpect(config_file: PathBuf) -> rexpect::errors::Result<()> {
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.08s
     Running unittests (target/debug/deps/the_way-2476d22413908dd3)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/the_way-79fb75f1bab7cc08)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/cli.rs (target/debug/deps/cli-3cfbdca97a40350f)

running 13 tests
test add_snippet ... ignored
test add_two_cmd_snippets ... ok
test add_two_snippets ... ok
test change_config_file ... ok
test change_snippet ... ok
test change_theme ... ok
test delete ... ok
test export ... ok
test import_gist ... ignored
test import_multiple_no_tags ... ok
test import_single_show ... ok
test it_works ... ok
test sync_gist ... ignored

test result: ok. 10 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 31.54s

   Doc-tests the-way

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```