### PR TITLE
Ask user before opening editor to edit snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - ???
+### Changed
+
+* Prompt user to open snippet in editor when editing existing snippet. #104
+
 ## [0.14.4] - 2021-09-05
 ### Fixed
 * .deb package extended description

--- a/src/the_way/snippet.rs
+++ b/src/the_way/snippet.rs
@@ -101,18 +101,28 @@ impl Snippet {
             .and_hms(0, 0, 0),
             None => Utc::now(),
         };
-        let show_default = old_code
-            .map(|c| c.split('\n').nth(1).is_none())
-            .unwrap_or(false);
-        let mut code = utils::user_input(
-            "Code snippet (<RET> to edit in external editor)",
-            if show_default { old_code } else { None },
-            show_default,
-            true,
-        )?;
-        if code.is_empty() {
-            code = utils::external_editor_input(old_code.as_deref(), &extension)?;
-        }
+
+        let code = match old_code {
+            Some(old) => {
+                if utils::confirm("Edit snippet? [y/N]", false)? {
+                    utils::external_editor_input(old_code.as_deref(), &extension)?
+                } else {
+                    old.to_string()
+                }
+            }
+            None => {
+                let mut input = utils::user_input(
+                    "Code snippet (leave empty to open external editor)",
+                    None,  // default
+                    false, // show default
+                    true,  // allow empty
+                )?;
+                if input.is_empty() {
+                    input = utils::external_editor_input(None, &extension)?;
+                }
+                input
+            }
+        };
         Ok(Self::new(
             index,
             description,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use std::str;
 use chrono::{Date, DateTime, Utc, MAX_DATE, MIN_DATE};
 use chrono_english::{parse_date_string, Dialect};
 use color_eyre::Help;
-use dialoguer::{Editor, Input};
+use dialoguer::{Confirm, Editor, Input};
 use syntect::highlighting::Style;
 use syntect::util::as_24_bit_terminal_escaped;
 
@@ -165,6 +165,16 @@ pub fn user_input(
             .trim()
             .to_owned()),
     }
+}
+
+/// Get a yes/no answer from the user
+pub fn confirm(prompt: &str, default: bool) -> color_eyre::Result<bool> {
+    let theme = dialoguer::theme::ColorfulTheme::default();
+    Ok(Confirm::with_theme(&theme)
+        .with_prompt(prompt)
+        .default(default)
+        .show_default(false)
+        .interact()?)
 }
 
 /// Make an indicatif spinner with given message

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -162,8 +162,8 @@ fn change_snippet_rexpect(config_file: PathBuf) -> rexpect::errors::Result<()> {
     p.send_line("")?;
     p.exp_regex("Date")?;
     p.send_line("")?;
-    p.exp_regex("Code snippet")?;
-    p.send_line("code 2")?;
+    p.exp_regex("Edit snippet")?;
+    p.send_line("")?;
     p.exp_regex("Snippet #1 changed")?;
     p.wait_for_prompt()?;
     p.send_line(&format!("{} view 1", executable))?;


### PR DESCRIPTION
Changes the behaviour around editing a snippet. Instead of always editing single line snippets in line and always editing multiline snippets in an external editor, check if the user wants to edit the snippet and then always open the editor.

The prompt is also changed for both new and editing snippets for clarity:
> Code snippet (leave empty to open in external editor)

for new snippets, and
> Edit snippet? [y/N]

for existing snippets.

Tests all pass but change_snippet no longer edits content as I'm not sure how well rexpect deals with external editors.

Fixes #104