### PR TITLE
Fix broken CONTRIBUTING link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 <!--
 Please, make sure:
 - you have read the contributing guidelines:
-  https://github.com/out-of-cheese-error/the-way/blob/master/docs/CONTRIBUTING.md
+  https://github.com/out-of-cheese-error/the-way/blob/master/CONTRIBUTING.md
 - you have linted the code using clippy:
   https://github.com/rust-lang/rust-clippy
 - you have formatted the code using rustfmt:


### PR DESCRIPTION
Noticed CONTRIBUTING link was giving me 404 when submitting the other PR
