### PR TITLE
Adds full path to default config for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ taken from [bat](https://github.com/sharkdp/bat/blob/master/assets/patches/Markd
 ## Configuration
 The default config TOML file is located in
 * Linux: `/home/<username>/.config/the-way`
-* Mac: `/Users/<username>/Library/Preferences`
+* Mac: `/Users/<username>/Library/Preferences/rs.the-way`
 
 This file contains locations of data directories, which are automatically created and set according to XDG and Standard Directories guidelines.
 Change this by creating a config file with `the-way config default > config.toml` and then setting the environment variable `$THE_WAY_CONFIG` to point to this file.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ taken from [bat](https://github.com/sharkdp/bat/blob/master/assets/patches/Markd
 
 ## Configuration
 The default config TOML file is located in
-* Linux: `/home/<username>/.config`
+* Linux: `/home/<username>/.config/the-way`
 * Mac: `/Users/<username>/Library/Preferences`
 
 This file contains locations of data directories, which are automatically created and set according to XDG and Standard Directories guidelines.


### PR DESCRIPTION
This adds the full path to the default config directory for linux in which `config.toml` is located by default.