### PR TITLE
Feat/improve copy to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - ???
+### Added
+* Field `copy_cmd` in configuration file which allows user to change the default copy command.
+  In case of empty field value (empty string) the default command is used.
+  ([PR 118](https://github.com/out-of-cheese-error/the-way/pull/118))
+* Enum error `NoDefaultCopyCommand` to represent the case where the OS copy
+  command is not supported by default.
+
+### Changed
+* Apply the Clippy's recommendations for the snippet.rs file.
+
 ## [0.15.0] - 2022-01-07
 ### Added
 * Search in code as well as description/tags (Issue [115](https://github.com/out-of-cheese-error/the-way/issues/115))
@@ -280,8 +291,9 @@ I'll make sure to add changes to it from now, the previous two releases weren't 
 - A first working version of the-way
 - cargo install option
 
+[0.16.0]: https://github.com/out-of-cheese-error/the-way/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/out-of-cheese-error/the-way/compare/v0.14.4...v0.15.0
 [0.14.4]: https://github.com/out-of-cheese-error/the-way/compare/v0.14.3...v0.14.4
-
 [0.14.3]: https://github.com/out-of-cheese-error/the-way/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/out-of-cheese-error/the-way/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/out-of-cheese-error/the-way/compare/v0.14.0...v0.14.1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release](https://img.shields.io/github/release/out-of-cheese-error/the-way.svg)](https://GitHub.com/out-of-cheese-error/the-way/releases/)
 [![dependency status](https://deps.rs/repo/github/out-of-cheese-error/the-way/status.svg)](https://deps.rs/repo/github/out-of-cheese-error/the-way)
 [![GitHub license](https://img.shields.io/github/license/out-of-cheese-error/the-way.svg)](https://github.com/out-of-cheese-error/the-way/blob/master/LICENSE)
-   
+
 # The Way
 A code snippets manager for your terminal.
 
@@ -259,6 +259,15 @@ The default config TOML file is located in
 
 This file contains locations of data directories, which are automatically created and set according to XDG and Standard Directories guidelines.
 Change this by creating a config file with `the-way config default > config.toml` and then setting the environment variable `$THE_WAY_CONFIG` to point to this file.
+
+### Copy command
+By default `xclip` is used on Linux, `pbcopy` on OSX and `termux-clipboard-set` on Android.
+You can override the default command by setting the `copy_cmd` field in the configuration file.
+For example to use `xsel` as a copy command, set the `copy_cmd` field as follows:
+
+```toml
+copy_cmd = 'xsel -ib'
+```
 
 # Why "The Way"?
 The name is a reference to [the Way of Mrs.Cosmopilite](https://wiki.lspace.org/mediawiki/The_Way_of_Mrs._Cosmopilite), kōans for every situation.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,6 +30,11 @@ pub enum LostTheWay {
     SyntaxError { syntax: String },
     #[error("ClipboardError: Couldn't copy to clipboard - {message}")]
     ClipboardError { message: String },
+    #[error(
+        "NoDefaultCopyCommand: No default command found for detected OS. \
+        Please add a supported command to your configuration file (as copy_cmd)"
+    )]
+    NoDefaultCopyCommand,
     #[error("SearchError: Search failed")]
     SearchError,
     /// Errors related to changing the configuration file

--- a/src/the_way/mod.rs
+++ b/src/the_way/mod.rs
@@ -189,7 +189,7 @@ impl TheWay {
                 }
             }
         } else {
-            utils::copy_to_clipboard(&code)?;
+            utils::copy_to_clipboard(&self.config.copy_cmd, &code)?;
             eprintln!(
                 "{}",
                 self.highlight_string(&format!("Snippet #{} copied to clipboard", index))

--- a/src/the_way/snippet.rs
+++ b/src/the_way/snippet.rs
@@ -39,6 +39,7 @@ pub struct Snippet {
 
 impl Snippet {
     /// New snippet
+    #[allow(clippy::too_many_arguments)]
     fn new(
         index: usize,
         description: String,
@@ -291,9 +292,11 @@ impl Snippet {
             let mut parts = capture["parameter"].split('=');
             let parameter_name = parts.next().unwrap().to_owned();
             let default = parts.next();
-            if !filled_parameters.contains_key(&parameter_name) {
+            if let std::collections::hash_map::Entry::Vacant(e) =
+                filled_parameters.entry(parameter_name.clone())
+            {
                 let filled = utils::user_input(&parameter_name, default, true, false)?;
-                filled_parameters.insert(parameter_name, filled);
+                e.insert(filled);
             }
         }
 


### PR DESCRIPTION
Adding a new field (`copy_cmd`) in the default configuration and in the configuration file.
It allows to easily add a new copy command.