### PR TITLE
Don't save github access token if environment variable set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Don't save environment variable `THE_WAY_GITHUB_TOKEN` to config file
+- If `THE_WAY_GITHUB_TOKEN` not set and `github_access_token` not in config file, prompt for token and prompt for saving to config file
+
 ## [0.16.1] - 2022-02-19
 ### Added
 - `--colorize` flag to force colorization even in non-tty environments.

--- a/src/the_way/gist.rs
+++ b/src/the_way/gist.rs
@@ -271,7 +271,12 @@ impl TheWay {
     }
 
     /// Syncs local and Gist snippets according to user-selected source
-    pub(crate) fn sync_gist(&mut self, source: SyncCommand, force: bool) -> color_eyre::Result<()> {
+    pub(crate) fn sync_gist(
+        &mut self,
+        github_access_token: Option<&str>,
+        source: SyncCommand,
+        force: bool,
+    ) -> color_eyre::Result<()> {
         // Retrieve local snippets
         let mut snippets = self.list_snippets()?;
         if snippets.is_empty() && source == SyncCommand::Local {
@@ -279,7 +284,7 @@ impl TheWay {
             return Ok(());
         }
         // Make client
-        let client = GistClient::new(self.config.github_access_token.as_deref())?;
+        let client = GistClient::new(github_access_token)?;
 
         // Start sync
         let spinner = utils::get_spinner("Syncing...");
@@ -301,8 +306,7 @@ impl TheWay {
                 "Gist not found.",
                 self.highlighter.main_style,
             ));
-            self.config.gist_id =
-                Some(self.make_gist(self.config.github_access_token.as_ref().unwrap())?);
+            self.config.gist_id = Some(self.make_gist(github_access_token.as_ref().unwrap())?);
             return Ok(());
         }
         let gist = gist?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -676,6 +676,7 @@ fn sync_date() -> color_eyre::Result<()> {
     // sync - downloads snippet_1 locally + deletes snippet_2 in Gist + adds snippet_3 to Gist
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("sync")
         .arg("date")
         .assert()
@@ -690,6 +691,7 @@ fn sync_date() -> color_eyre::Result<()> {
     // sync again - nothing changed
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("sync")
         .arg("date")
         .assert()
@@ -744,6 +746,7 @@ fn sync_local() -> color_eyre::Result<()> {
     // sync - uploads local snippet_1 to Gist + deletes snippet_2 from Gist + adds snippet_3 to Gist
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("sync")
         .arg("local")
         .assert()
@@ -758,6 +761,7 @@ fn sync_local() -> color_eyre::Result<()> {
     // sync again - nothing changed
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("sync")
         .arg("local")
         .assert()
@@ -782,6 +786,7 @@ fn sync_local() -> color_eyre::Result<()> {
     // check snippet_1 not downloaded
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("view")
         .arg("1")
         .assert()
@@ -813,6 +818,7 @@ fn sync_gist() -> color_eyre::Result<()> {
     // sync - downloads snippet 1 locally + adds snippet 2 locally + deletes snippet 3 locally
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("sync")
         .arg("-f")
         .arg("gist")
@@ -828,6 +834,7 @@ fn sync_gist() -> color_eyre::Result<()> {
     // sync again - nothing changed
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("sync")
         .arg("gist")
         .assert()
@@ -851,6 +858,7 @@ fn sync_gist() -> color_eyre::Result<()> {
     // downloaded snippet_1 locally
     let mut cmd = Command::cargo_bin("the-way")?;
     cmd.env("THE_WAY_CONFIG", &config_file)
+        .env("THE_WAY_GITHUB_TOKEN", token)
         .arg("view")
         .arg("1")
         .assert()


### PR DESCRIPTION
if THE_WAY_GITHUB_TOKEN set, use that and don't save to config file
if
token not in environment variable or in config file, ask user to enter
token and ask again to save it to config file

Closes #132